### PR TITLE
Fix ext-proc socket address

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -102,5 +102,5 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: ext_proc
+                      address: ext-proc
                       port_value: 50051


### PR DESCRIPTION
Fixes 500s.
Seen via these logs

```
envoy                 | [2025-06-26 12:13:47.365][14][debug][upstream] [source/common/upstream/cluster_manager_impl.cc:1978] no healthy host for HTTP connection pool
envoy                 | [2025-06-26 12:13:47.365][14][debug][http] [source/common/http/async_client_impl.cc:178] async http request response headers (end_stream=true):
envoy                 | ':status', '200'
envoy                 | 'content-type', 'application/grpc'
envoy                 | 'grpc-status', '14'
envoy                 | 'grpc-message', 'no healthy upstream'
```